### PR TITLE
Basic NixOS support.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,9 @@
+{ pkgs ? import <nixpkgs> {} }:
+  pkgs.mkShell {
+    nativeBuildInputs = with pkgs.buildPackages; [ 
+	perl
+	perlPackages.Curses
+	perlPackages.CGI
+	perlPackages.IOSocketSSL
+    ];
+}

--- a/tlily.PL
+++ b/tlily.PL
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #    TigerLily:  A client for the lily CMC, written in Perl.
 #    Copyright (C) 1999-2011  The TigerLily Team, <tigerlily@tlily.org>
 #                                http://www.tlily.org/tigerlily/


### PR DESCRIPTION
This is enough to make tlily.PL run on NixOS,
and have SSL support.